### PR TITLE
Basemap changed to OpenStreetMap

### DIFF
--- a/config/map.json
+++ b/config/map.json
@@ -14,7 +14,7 @@
             49.72867079292322
         ]
     },
-    "baseMap": "StamenTonerLight",
+    "baseMap": "Streets",
     "minZoom": 10,
     "activeTool": "directions"
   },


### PR DESCRIPTION
This changes the basemap to be OpenStreetMap, as requested in https://github.com/bcgov/smk-tlink/issues/220.