### PR TITLE
Enable querying on the Provincial Highways layers in the truck route group

### DIFF
--- a/layers/provincial-highway/config.json
+++ b/layers/provincial-highway/config.json
@@ -44,6 +44,30 @@
             "dataUrl": "./layers/provincial-highway/provincial-highway.geojson",
             "metadataUrl": "https://catalogue.data.gov.bc.ca/dataset/0636a01a-a13f-48f9-94cf-1c0e59b3ba6b",
             "scaleMin": 23167,
+            "attributes": [
+                {
+                    "name": "Municipality",
+                    "title": "Municipality"
+                },
+                {
+                    "name": "RouteType",
+                    "title": "Truck Route Type"
+                },
+                {
+                    "name": "Bylaw",
+                    "title": "Bylaw Link",
+                    "format": "asLink(this.feature.properties.BylawLink)"
+                },
+                {
+                    "name": "TruckDefinitionWeight",
+                    "title": "Heavy Truck Definition (LGVW)",
+                    "format": "asUnit('kg')"
+                },
+                {
+                    "name": "Notes",
+                    "title": "Notes"
+                }
+            ],
             "style": {
                 "strokeWidth": 3,
                 "strokeColor": "#267300",
@@ -61,6 +85,30 @@
             "dataUrl": "./layers/provincial-highway/provincial-highway.geojson",
             "metadataUrl": "https://catalogue.data.gov.bc.ca/dataset/0636a01a-a13f-48f9-94cf-1c0e59b3ba6b",
             "scaleMax": 23167,
+            "attributes": [
+                {
+                    "name": "Municipality",
+                    "title": "Municipality"
+                },
+                {
+                    "name": "RouteType",
+                    "title": "Truck Route Type"
+                },
+                {
+                    "name": "Bylaw",
+                    "title": "Bylaw Link",
+                    "format": "asLink(this.feature.properties.BylawLink)"
+                },
+                {
+                    "name": "TruckDefinitionWeight",
+                    "title": "Heavy Truck Definition (LGVW)",
+                    "format": "asUnit('kg')"
+                },
+                {
+                    "name": "Notes",
+                    "title": "Notes"
+                }
+            ],
             "style": {
                 "strokeWidth": 1.5,
                 "strokeColor": "#267300",

--- a/layers/provincial-highway/config.json
+++ b/layers/provincial-highway/config.json
@@ -44,7 +44,6 @@
             "dataUrl": "./layers/provincial-highway/provincial-highway.geojson",
             "metadataUrl": "https://catalogue.data.gov.bc.ca/dataset/0636a01a-a13f-48f9-94cf-1c0e59b3ba6b",
             "scaleMin": 23167,
-            "isQueryable": false,
             "style": {
                 "strokeWidth": 3,
                 "strokeColor": "#267300",
@@ -62,7 +61,6 @@
             "dataUrl": "./layers/provincial-highway/provincial-highway.geojson",
             "metadataUrl": "https://catalogue.data.gov.bc.ca/dataset/0636a01a-a13f-48f9-94cf-1c0e59b3ba6b",
             "scaleMax": 23167,
-            "isQueryable": false,
             "style": {
                 "strokeWidth": 1.5,
                 "strokeColor": "#267300",


### PR DESCRIPTION
Remove queryable = false from the config for truck-routes-provincial-highway-high-zoom and truck-routes-provincial-highway layers in order to allow the identify tool to work. Queryable is true by default, so no need to set queryable = true.

This is a fix for https://github.com/bcgov/smk-tlink/issues/224.