### PR TITLE
Change default basemap to StamenTonerLight (#220)

### DIFF
--- a/config/map.json
+++ b/config/map.json
@@ -14,7 +14,7 @@
             49.72867079292322
         ]
     },
-    "baseMap": "Streets",
+    "baseMap": "StamenTonerLight",
     "esriApiKey": "AAPKacb4ff83a3e34b4887bed2d86c318279EXFibvw9GBGQCOMSQBVRdU3aaWqj6GrdbTKGtSxq6MXtukzb2O7CSwa_bv1iY3ia",
     "minZoom": 10,
     "activeTool": "directions"


### PR DESCRIPTION
This reverts the change from StamenTonerLight to Streets, originally requested in https://github.com/bcgov/smk-tlink/issues/220 and updated to restore StamenTonerLight.