### PR TITLE
Change basemap to Gray

### DIFF
--- a/config/map.json
+++ b/config/map.json
@@ -14,7 +14,7 @@
             49.72867079292322
         ]
     },
-    "baseMap": "StamenTonerLight",
+    "baseMap": "Gray",
     "minZoom": 10,
     "activeTool": "directions"
   },
@@ -78,7 +78,6 @@
         "Topographic",
         "Streets",
         "Imagery",
-        "StamenTonerLight",
         "DarkGray",
         "Gray"
       ],


### PR DESCRIPTION
Support for the free service of Stamen basemaps is ending on October 31. This changes the basemap from Stamen Toner Light to Gray and removes Stamen Toner Light from the available choices in the Base Maps tool.