### PR TITLE
Prepare layer MRN High Zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,6 +293,7 @@
                 prepareLayer( 'industrial-area' )
                 prepareLayer( 'inspection-station' )
                 prepareLayer( 'major-road-network' )
+                prepareLayer( 'major-road-network-high-zoom' )
                 prepareLayer( 'metro-vancouver-boundary' )
 
                 function isSign( prop ) {


### PR DESCRIPTION
The Major Road Network High Zoom layer does not seem to appear in the app at the highest zoom level, where it seems we transition from the Major Road Network layer. It looks like the MRN High Zoom layer is not loading.

This change updates the index page to call prepareLayer() for the MRN High Zoom Layer in addition to the existing call to prepare the MRN layer.